### PR TITLE
Adding version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "leaflet-polylinedecorator",
+  "version": "1.0.0",
   "repository": "bbecquet/Leaflet.PolylineDecorator",
   "devDependencies": {
     "gulp": "^3.9.0",


### PR DESCRIPTION
npm requires a version to use the package as a dependency