### PR TITLE
Add ability to set an angle correction

### DIFF
--- a/src/L.Symbol.js
+++ b/src/L.Symbol.js
@@ -123,7 +123,7 @@ L.Symbol.Marker = L.Class.extend({
             return new L.Marker(directionPoint.latLng, this.options.markerOptions);
         }
         else {
-            this.options.markerOptions.angle = directionPoint.heading;
+            this.options.markerOptions.angle = directionPoint.heading + (this.options.angleCorrection || 0);
             return new L.RotatedMarker(directionPoint.latLng, this.options.markerOptions);
         }
     }


### PR DESCRIPTION
Hello, @bbecquet! Your plugin is very useful but It has no way to set angle correction in some specific cases.

For example, I have an image like following:

![arrow-up](https://cloud.githubusercontent.com/assets/825219/12870224/edd42ee6-cd4b-11e5-9026-95e778952dd9.png)

If I create a marker with following settings:

```javascript
L.Symbol.marker({
  markerOptions: {
     icon: L.icon({
       iconSize: [50,15],
       iconUrl: './some-path/arrow-up.png'
     })
  }
});
```
I will get something like this:

![2016-02-07 3 38 13](https://cloud.githubusercontent.com/assets/825219/12870237/79eeb7a2-cd4c-11e5-8eca-da7596972f4b.png)

If I set "rotate: true", I'll get following:

![2016-02-07 3 21 37](https://cloud.githubusercontent.com/assets/825219/12870243/0e3d3e42-cd4d-11e5-8492-a918bcb5c696.png)

But I want to get something like this:

![2016-02-07 3 20 44](https://cloud.githubusercontent.com/assets/825219/12870245/25be2e6e-cd4d-11e5-91d8-55ece7050752.png)

In this PR I've already implemented a small addition to "L.Symbol.marker" API. Now we can set "angleCorrection: 90" (for example) to correct marker's angle.

```javascript
L.Symbol.marker({
  markerOptions: {
     rotate: true,
     angleCorrection: 90,
     icon: L.icon({
       iconSize: [50,15],
       iconUrl: './some-path/arrow-up.png'
     })
  }
});
```

I think it will be useful not only for me.