### PR TITLE
Extend from FeatureGroup instead of LayerGroup

### DIFF
--- a/src/L.PolylineDecorator.js
+++ b/src/L.PolylineDecorator.js
@@ -1,11 +1,11 @@
 
-L.PolylineDecorator = L.LayerGroup.extend({
+L.PolylineDecorator = L.FeatureGroup.extend({
     options: {
         patterns: []
     },
 
     initialize: function(paths, options) {
-        L.LayerGroup.prototype.initialize.call(this);
+        L.FeatureGroup.prototype.initialize.call(this);
         L.Util.setOptions(this, options);
         this._map = null;
         this._initPaths(paths);


### PR DESCRIPTION
Allows for some more flexibility in click handling(https://github.com/bbecquet/Leaflet.PolylineDecorator/issues/44) ..and also doesn't cause `getBounds()` to fail when added alongside other types of Layers.