### PR TITLE
[Decorator] Fix Polyline array instanciation

### DIFF
--- a/src/L.PolylineDecorator.js
+++ b/src/L.PolylineDecorator.js
@@ -29,7 +29,7 @@ L.PolylineDecorator = L.FeatureGroup.extend({
         } else if (L.Util.isArray(p) && p.length > 0) {
             if (p[0] instanceof L.Polyline) {
                 p.forEach(singleP => {
-                    this._initPath(singleP, (single instanceof L.Polygon));
+                    this._initPath(singleP, (singleP instanceof L.Polygon));
                 });
             } else {
                 this._initPath(p);


### PR DESCRIPTION
What:
Instanciating PolylineDecorator on a Polyline array result on an error.

Why:
This is due to a typo error in the internal function _initPaths in charge
of harmonizing the paths given to the PolylineDecorator.

How:
Fix the typo error in the _initPath() function.

Refs: #68