### PR TITLE
Fix for calling _initPatterns

### DIFF
--- a/dist/leaflet.polylineDecorator.js
+++ b/dist/leaflet.polylineDecorator.js
@@ -348,7 +348,7 @@ L$1.PolylineDecorator = L$1.FeatureGroup.extend({
     */
     setPatterns: function setPatterns(patterns) {
         this.options.patterns = patterns;
-        this._patterns = _initPatterns(this.options.patterns);
+        this._patterns = this._initPatterns(this.options.patterns);
         this.redraw();
     },
 


### PR DESCRIPTION
Not sure why this commit has so many lines changed in the diff, but the only change was the following line;
`this._patterns = _initPatterns(this.options.patterns);`
to
`this._patterns = this._initPatterns(this.options.patterns);`

Not sure why it was missing `this` to begin with but I've added it since even though it was working previously, it seems to throw an error in Ember.js 2.17.0-beta.2