### PR TITLE
Fix for calling _initPatterns (properly this time)

### DIFF
--- a/dist/leaflet.polylineDecorator.js
+++ b/dist/leaflet.polylineDecorator.js
@@ -348,7 +348,7 @@ L$1.PolylineDecorator = L$1.FeatureGroup.extend({
     */
     setPatterns: function setPatterns(patterns) {
         this.options.patterns = patterns;
-        this._patterns = _initPatterns(this.options.patterns);
+        this._patterns = this._initPatterns(this.options.patterns);
         this.redraw();
     },
 

--- a/src/L.PolylineDecorator.js
+++ b/src/L.PolylineDecorator.js
@@ -62,7 +62,7 @@ L.PolylineDecorator = L.FeatureGroup.extend({
     */
     setPatterns: function(patterns) {
         this.options.patterns = patterns;
-        this._patterns = _initPatterns(this.options.patterns);
+        this._patterns = this._initPatterns(this.options.patterns);
         this.redraw();
     },
 


### PR DESCRIPTION
Changed
`this._patterns = _initPatterns(this.options.patterns);`
to
`this._patterns = this._initPatterns(this.options.patterns);`

Otherwise it seems to throw an error in Ember.js 2.17.0-beta.2

Did it properly this time, by editing the `/src/L.PolylineDecorator.js` file and then running `npm install` followed by `npm run build` to generate the equivalent dist file