### PR TITLE
fixes issue #86: Decorators drawn when offset larger than line length

### DIFF
--- a/src/patternUtils.js
+++ b/src/patternUtils.js
@@ -59,16 +59,19 @@ function projectPatternOnPointPath(pts, pattern) {
     const endOffset = asRatioToPathLength(pattern.endOffset, totalPathLength);
     const repeat = asRatioToPathLength(pattern.repeat, totalPathLength);
 
-    const repeatIntervalPixels = totalPathLength * repeat;
-    const startOffsetPixels = offset > 0 ? totalPathLength * offset : 0;
-    const endOffsetPixels = endOffset > 0 ? totalPathLength * endOffset : 0;
-
     // 2. generate the positions of the pattern as offsets from the path start
     const positionOffsets = [];
-    let positionOffset = startOffsetPixels;
-    while(repeatIntervalPixels > 0 && positionOffset < totalPathLength - endOffsetPixels) {
-        positionOffsets.push(positionOffset);
-        positionOffset += repeatIntervalPixels;
+    if (repeat) {
+      const repeatIntervalPixels = totalPathLength * repeat;
+      const endOffsetPixels = endOffset > 0 ? totalPathLength * endOffset : 0;
+      let positionOffset = offset > 0 ? totalPathLength * offset : 0;
+
+      while(repeatIntervalPixels > 0 && positionOffset < totalPathLength - endOffsetPixels) {
+          positionOffsets.push(positionOffset);
+          positionOffset += repeatIntervalPixels;
+      }
+    } else {
+      positionOffsets.push(offset > 0 ? totalPathLength * offset : 0);
     }
 
     // 3. projects offsets to segments

--- a/src/patternUtils.js
+++ b/src/patternUtils.js
@@ -66,10 +66,10 @@ function projectPatternOnPointPath(pts, pattern) {
     // 2. generate the positions of the pattern as offsets from the path start
     const positionOffsets = [];
     let positionOffset = startOffsetPixels;
-    do {
+    while(repeatIntervalPixels > 0 && positionOffset < totalPathLength - endOffsetPixels) {
         positionOffsets.push(positionOffset);
         positionOffset += repeatIntervalPixels;
-    } while(repeatIntervalPixels > 0 && positionOffset < totalPathLength - endOffsetPixels);
+    }
 
     // 3. projects offsets to segments
     let segmentIndex = 0;

--- a/src/patternUtils.js
+++ b/src/patternUtils.js
@@ -66,7 +66,7 @@ function projectPatternOnPointPath(pts, pattern) {
       const endOffsetPixels = endOffset > 0 ? totalPathLength * endOffset : 0;
       let positionOffset = offset > 0 ? totalPathLength * offset : 0;
 
-      while(repeatIntervalPixels > 0 && positionOffset < totalPathLength - endOffsetPixels) {
+      while(repeatIntervalPixels > 0 && positionOffset <= totalPathLength - endOffsetPixels) {
           positionOffsets.push(positionOffset);
           positionOffset += repeatIntervalPixels;
       }


### PR DESCRIPTION
I just noticed the issue which already has been posted as #86. Before finding the pull request #87, which fixes this issue, I already found a different solution, which is much simpler and even reduces code instead of extending it.